### PR TITLE
Store CI artifacts

### DIFF
--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -72,7 +72,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: iOS build
-          path: '~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app'
+          path: |
+            ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app
+            ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app.dSYM
 
   iosTest:
     runs-on: macos-latest

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -38,11 +38,11 @@ jobs:
         with:
           report_paths: 'kmm/**/build/test-results/**/TEST-*.xml'
           check_name: 'KMM Test Report'
-      - name: Saving artifacts
+      - name: Save artifacts
         uses: actions/upload-artifact@v3
         if: always() # Always run even if the previous step fails to collect all reports
         with:
-          name: Test results
+          name: KMM test results
           path: 'kmm/**/build/test-results/**/TEST-*.xml'
 
   iosBuild:
@@ -153,9 +153,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: set -o pipefail && ./gradlew connectedAndroidTest
-      - name: Saving artifacts
+      - name: Save artifacts
         uses: actions/upload-artifact@v3
         if: always() # Always run even if the previous step fails to collect all reports
         with:
-          name: Test results
+          name: Android test results
           path: 'appAndroid/**/build/outputs/androidTest-results/connected/**/test-result.pb'

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -54,7 +54,7 @@ jobs:
           path: 'kmm/**/build/test-results/**/TEST-*.xml'
 
   iosBuild:
-    runs-on: macos-latest
+    runs-on: macos-11
     concurrency:
       group: ${{ github.ref }}_iosBuild
       cancel-in-progress: true
@@ -91,7 +91,7 @@ jobs:
             ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app.dSYM
 
   iosTest:
-    runs-on: macos-latest
+    runs-on: macos-11
     concurrency:
       group: ${{ github.ref }}_iosTest
       cancel-in-progress: true
@@ -150,8 +150,8 @@ jobs:
           path: 'appAndroid/**/build/**/appAndroid-*.apk'
 
   androidTest:
-    # Needed because of hardware acceleration
-    runs-on: macos-latest
+    # Needed because of hardware acceleration for the emulator
+    runs-on: macos-11
     concurrency:
       group: ${{ github.ref }}_androidTest
       cancel-in-progress: true

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -68,6 +68,11 @@ jobs:
         run: |
           cd appIos
           set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' build | xcpretty
+      - name: Save artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: iOS build
+          path: '~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app'
 
   iosTest:
     runs-on: macos-latest

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -30,6 +30,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
       - name: Generate KMM test report
@@ -62,6 +67,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: Compile iOS app
@@ -93,6 +103,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: iOS tests
@@ -115,6 +130,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
       - name: Save artifacts
@@ -138,6 +158,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: Android build
-          path: 'appAndroid/appAndroid/build/intermediates/apk/**/*.apk'
+          path: 'appAndroid/**/build/**/appAndroid-*.apk'
 
   androidTest:
     runs-on: macos-latest

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           name: iOS build
           path: |
-            xcodebuild.log
+            appIos/xcodebuild.log
             ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app
             ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app.dSYM
 
@@ -125,7 +125,7 @@ jobs:
         with:
           name: iOS test results
           path: |
-            xcodebuild.log
+            appIos/xcodebuild.log
 
   androidBuild:
     runs-on: ubuntu-20.04

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -30,11 +30,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-      - name: KMM cache
-        uses: actions/cache@v2
-        id: kmm-cache
-        with:
-          path: '~/.konan/*'
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
       - name: Generate KMM test report
@@ -67,11 +62,6 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-      - name: KMM cache
-        uses: actions/cache@v2
-        id: kmm-cache
-        with:
-          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: Compile iOS app
@@ -103,11 +93,6 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-      - name: KMM cache
-        uses: actions/cache@v2
-        id: kmm-cache
-        with:
-          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: iOS tests
@@ -130,11 +115,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-      - name: KMM cache
-        uses: actions/cache@v2
-        id: kmm-cache
-        with:
-          path: '~/.konan/*'
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
       - name: Save artifacts
@@ -158,11 +138,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
-      - name: KMM cache
-        uses: actions/cache@v2
-        id: kmm-cache
-        with:
-          path: '~/.konan/*'
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -30,6 +30,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
       - name: Generate KMM test report

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -32,10 +32,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: KMM cache
         uses: actions/cache@v2
-        id: kmm-cache
+        id: konan-kmm
         with:
-          path: '~/.konan/*'
-          key: konan
+          path: '~/.konan/**'
+          key: konan-kmm
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
       # Always run this job even if the previous steps fail to collect all test reports
@@ -72,10 +72,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: KMM cache
         uses: actions/cache@v2
-        id: kmm-cache
+        id: konan-ios
         with:
-          path: '~/.konan/*'
-          key: konan
+          path: '~/.konan/**'
+          key: konan-ios
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: Compile iOS app
@@ -110,10 +110,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: KMM cache
         uses: actions/cache@v2
-        id: kmm-cache
+        id: konan-ios-test
         with:
-          path: '~/.konan/*'
-          key: konan
+          path: '~/.konan/**'
+          key: konan-ios-test
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: iOS tests
@@ -144,10 +144,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: KMM cache
         uses: actions/cache@v2
-        id: kmm-cache
+        id: konan-android
         with:
-          path: '~/.konan/*'
-          key: konan
+          path: '~/.konan/**'
+          key: konan-android
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
       - name: Save artifacts
@@ -174,10 +174,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: KMM cache
         uses: actions/cache@v2
-        id: kmm-cache
+        id: konan-android-test
         with:
-          path: '~/.konan/*'
-          key: konan
+          path: '~/.konan/**'
+          key: konan-android-test
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -38,15 +38,17 @@ jobs:
           key: konan
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
+      # Always run this job even if the previous steps fail to collect all test reports
       - name: Generate KMM test report
         uses: mikepenz/action-junit-report@v3
-        if: always() # Always run even if the previous step fails to collect all reports
+        if: always()
         with:
           report_paths: 'kmm/**/build/test-results/**/TEST-*.xml'
           check_name: 'KMM Test Report'
+      # Always run this job even if the previous steps fail to collect all artifacts
       - name: Save artifacts
         uses: actions/upload-artifact@v3
-        if: always() # Always run even if the previous step fails to collect all reports
+        if: always()
         with:
           name: KMM test results
           path: 'kmm/**/build/test-results/**/TEST-*.xml'
@@ -73,6 +75,7 @@ jobs:
         id: kmm-cache
         with:
           path: '~/.konan/*'
+          key: konan
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: Compile iOS app
@@ -109,6 +112,7 @@ jobs:
         id: kmm-cache
         with:
           path: '~/.konan/*'
+          key: konan
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: iOS tests
@@ -117,7 +121,7 @@ jobs:
           set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' test | xcpretty
 
   androidBuild:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}_androidBuild
       cancel-in-progress: true
@@ -136,6 +140,7 @@ jobs:
         id: kmm-cache
         with:
           path: '~/.konan/*'
+          key: konan
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
       - name: Save artifacts
@@ -145,7 +150,7 @@ jobs:
           path: 'appAndroid/**/build/**/appAndroid-*.apk'
 
   androidTest:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}_androidTest
       cancel-in-progress: true
@@ -164,6 +169,7 @@ jobs:
         id: kmm-cache
         with:
           path: '~/.konan/*'
+          key: konan
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache
@@ -191,9 +197,10 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: set -o pipefail && ./gradlew connectedAndroidTest
+      # Always run this job even if the previous steps fail to collect all artifacts
       - name: Save artifacts
         uses: actions/upload-artifact@v3
-        if: always() # Always run even if the previous step fails to collect all reports
+        if: always()
         with:
           name: Android test results
           path: 'appAndroid/**/build/outputs/androidTest-results/connected/**/test-result.pb'

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -150,7 +150,8 @@ jobs:
           path: 'appAndroid/**/build/**/appAndroid-*.apk'
 
   androidTest:
-    runs-on: ubuntu-latest
+    # Needed because of hardware acceleration
+    runs-on: macos-latest
     concurrency:
       group: ${{ github.ref }}_androidTest
       cancel-in-progress: true

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -67,6 +67,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: Compile iOS app
@@ -98,6 +103,11 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Xcode cache
         uses: mikehardy/buildcache-action@v1
       - name: iOS tests
@@ -120,6 +130,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
       - name: Save artifacts
@@ -143,6 +158,11 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
       - name: Gradle cache
         uses: gradle/gradle-build-action@v2
+      - name: KMM cache
+        uses: actions/cache@v2
+        id: kmm-cache
+        with:
+          path: '~/.konan/*'
       - name: AVD cache
         uses: actions/cache@v2
         id: avd-cache

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -110,6 +110,11 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Compile Android app
         run: set -o pipefail && ./gradlew appAndroid:assembleDebug
+      - name: Save artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: Android build
+          path: 'appAndroid/appAndroid/build/intermediates/apk/**/*.apk'
 
   androidTest:
     runs-on: macos-latest

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   kmmTest:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}_kmmTest
       cancel-in-progress: true

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   kmmTest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.ref }}_kmmTest
       cancel-in-progress: true
@@ -44,7 +44,7 @@ jobs:
         if: always()
         with:
           report_paths: 'kmm/**/build/test-results/**/TEST-*.xml'
-          check_name: 'KMM Test Report'
+          check_name: 'kmmTestResults'
       # Always run this job even if the previous steps fail to collect all artifacts
       - name: Save artifacts
         uses: actions/upload-artifact@v3
@@ -81,12 +81,13 @@ jobs:
       - name: Compile iOS app
         run: |
           cd appIos
-          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' build
+          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' build | tee xcodebuild.log | xcpretty
       - name: Save artifacts
         uses: actions/upload-artifact@v3
         with:
           name: iOS build
           path: |
+            xcodebuild.log
             ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app
             ~/Library/Developer/Xcode/DerivedData/**/Build/Products/**/appIos.app.dSYM
 
@@ -118,10 +119,16 @@ jobs:
       - name: iOS tests
         run: |
           cd appIos
-          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' test | xcpretty
+          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' test | tee xcodebuild.log | xcpretty
+      - name: Save artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: iOS test results
+          path: |
+            xcodebuild.log
 
   androidBuild:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.ref }}_androidBuild
       cancel-in-progress: true

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Compile iOS app
         run: |
           cd appIos
-          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' build | xcpretty
+          set -o pipefail && xcodebuild ${{ env.XCODE_CACHE }} -workspace appIos.xcworkspace -scheme "appIos" -sdk iphonesimulator -destination '${{ env.IOS_SIMULATOR }}' build
       - name: Save artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           report_paths: 'kmm/**/build/test-results/**/TEST-*.xml'
           check_name: 'KMM Test Report'
+      - name: Saving artifacts
+        uses: actions/upload-artifact@v3
+        if: always() # Always run even if the previous step fails to collect all reports
+        with:
+          name: Test results
+          path: 'kmm/**/build/test-results/**/TEST-*.xml'
 
   iosBuild:
     runs-on: macos-latest
@@ -147,3 +153,9 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: set -o pipefail && ./gradlew connectedAndroidTest
+      - name: Saving artifacts
+        uses: actions/upload-artifact@v3
+        if: always() # Always run even if the previous step fails to collect all reports
+        with:
+          name: Test results
+          path: 'appAndroid/**/build/outputs/androidTest-results/connected/**/test-result.pb'

--- a/.github/workflows/check_build.yml
+++ b/.github/workflows/check_build.yml
@@ -35,6 +35,7 @@ jobs:
         id: kmm-cache
         with:
           path: '~/.konan/*'
+          key: konan
       - name: KMM tests
         run: set -o pipefail && ./gradlew --continue testDebugUnitTest
       - name: Generate KMM test report

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Demo
 
-Optional but helps to have a quick visual, if any.
+*Optional but helps to have a quick visual, if any.*
 
 Before|After
 -|-
@@ -14,7 +14,7 @@ Before|After
 
 ## Screenshots
 
-Optional but helps to have a quick visual, if any.
+*Optional but helps to have a quick visual, if any.*
 
 Before|After
 -|-


### PR DESCRIPTION
## What does this pull request change?

This PR makes the following improvements to the CI system:
- stores build artifacts for the different platforms (including the `.app`, `.apk`, build logs and test results files)
- adds cache support for the `~/.konan` directory where the KMM native compilers are downloaded and saved by Gradle
- tidy up the CI file

## Screenshots

<img width="1353" alt="Screenshot 2022-04-01 at 14 17 17" src="https://user-images.githubusercontent.com/7644787/161261600-fd1b4e01-50a6-4ed2-a304-6380bc79676e.png">

## How is this change tested?

With the existing CI checks

---

[Our testing guide](https://github.com/gchristov/newsfeed-kmm#-tests)
[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/multiplatform-run-tests.html)

