### PR TITLE
Prompt with the last used search query in iOS

### DIFF
--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -48,7 +48,7 @@ public struct FeedScreenContent: View {
         .onChange(of: searchQuery) { _ in
             viewModel.onSearchTextChanged(newQuery: searchQuery)
         }
-        .searchable(text: $searchQuery, prompt: "Search \(state?.searchQuery?.lowercased() ?? "" )")
+        .searchable(text: $searchQuery, prompt: "Search \(state?.searchQuery.lowercased() ?? "" )")
         .onAppear {
             setupViewModel()
         }

--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -48,7 +48,7 @@ public struct FeedScreenContent: View {
         .onChange(of: searchQuery) { _ in
             viewModel.onSearchTextChanged(newQuery: searchQuery)
         }
-        .searchable(text: $searchQuery, prompt: "Search articles...")
+        .searchable(text: $searchQuery, prompt: "Search \(state?.searchQuery?.lowercased() ?? "" )")
         .onAppear {
             setupViewModel()
         }

--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -49,7 +49,7 @@ public struct FeedScreenContent: View {
                     onLoadMore: { viewModel.loadNextPage(startFromFirst: false) },
                     onAppear: { viewModel.redecorateContent() },
                     onSearchChanged: { query in viewModel.onSearchTextChanged(newQuery: query) },
-                    currentSearchQuery: state?.searchQuery
+                    currentSearchQuery: state?.searchQuery ?? ""
                 )
             }
         }
@@ -125,7 +125,7 @@ private struct FeedState: View {
             .onChange(of: searchQuery) { _ in
                 onSearchChanged(searchQuery)
             }
-            .searchable(text: $searchQuery, prompt: "Search \"\(searchQuery.lowercased())\"")
+            .searchable(text: $searchQuery, prompt: "Search \"\(currentSearchQuery.lowercased())\"")
             .onAppear {
                 onAppear()
             }

--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -123,7 +123,7 @@ private struct FeedState: View {
             .onChange(of: searchQuery) { _ in
                 onSearchChanged(searchQuery)
             }
-            .searchable(text: $searchQuery, prompt: "Search \"\(searchQuery.lowercased())\"")
+            .searchable(text: $searchQuery, prompt: "Search \(searchQuery.lowercased())")
             .onAppear {
                 onAppear()
             }

--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -48,7 +48,8 @@ public struct FeedScreenContent: View {
                     onRefresh: { viewModel.refreshContent() },
                     onLoadMore: { viewModel.loadNextPage(startFromFirst: false) },
                     onAppear: { viewModel.redecorateContent() },
-                    onSearchChanged: { query in viewModel.onSearchTextChanged(newQuery: query) }
+                    onSearchChanged: { query in viewModel.onSearchTextChanged(newQuery: query) },
+                    currentSearchQuery: state?.searchQuery
                 )
             }
         }
@@ -91,6 +92,7 @@ private struct FeedState: View {
     let onLoadMore: () -> ()
     let onAppear: () -> ()
     let onSearchChanged: (String) -> ()
+    let currentSearchQuery: String
     
     var body: some View {
         AppNavigationView {

--- a/appIos/feed/feed/FeedScreen.swift
+++ b/appIos/feed/feed/FeedScreen.swift
@@ -123,7 +123,7 @@ private struct FeedState: View {
             .onChange(of: searchQuery) { _ in
                 onSearchChanged(searchQuery)
             }
-            .searchable(text: $searchQuery, prompt: "Search \(searchQuery.lowercased())")
+            .searchable(text: $searchQuery, prompt: "Search \"\(searchQuery.lowercased())\"")
             .onAppear {
                 onAppear()
             }

--- a/kmm/kmm-feed/src/commonMain/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModel.kt
+++ b/kmm/kmm-feed/src/commonMain/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModel.kt
@@ -92,7 +92,7 @@ class FeedViewModel(
             try {
                 val feedUpdate = getSectionedFeedUseCase(
                     pageId = nextPage,
-                    feedQuery = state.value.searchQuery ?: "brexit,fintech",
+                    feedQuery = state.value.searchQuery,
                     currentFeed = state.value.sectionedFeed,
                     // Only request cache if we're starting from the first page
                     onCache = if (startFromFirst) { cache ->
@@ -134,7 +134,7 @@ class FeedViewModel(
         val blockingError: Throwable? = null,
         val nonBlockingError: Throwable? = null,
         val sectionedFeed: SectionedFeed? = null,
-        val searchQuery: String? = null
+        val searchQuery: String = "brexit,fintech"
     )
 }
 

--- a/kmm/kmm-feed/src/commonMain/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModel.kt
+++ b/kmm/kmm-feed/src/commonMain/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModel.kt
@@ -92,7 +92,7 @@ class FeedViewModel(
             try {
                 val feedUpdate = getSectionedFeedUseCase(
                     pageId = nextPage,
-                    feedQuery = "brexit,fintech",
+                    feedQuery = state.value.searchQuery ?: "brexit,fintech",
                     currentFeed = state.value.sectionedFeed,
                     // Only request cache if we're starting from the first page
                     onCache = if (startFromFirst) { cache ->

--- a/kmm/kmm-feed/src/commonTest/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModelTest.kt
+++ b/kmm/kmm-feed/src/commonTest/kotlin/com/gchristov/newsfeed/kmmfeed/FeedViewModelTest.kt
@@ -22,11 +22,11 @@ class FeedViewModelTest : CommonViewModelTestClass() {
         runTest { viewModel, _, _ ->
             viewModel.onSearchTextChanged("te")
             delay(100)
-            assertTrue { viewModel.state.value.searchQuery == null }
+            assertTrue { viewModel.state.value.searchQuery == "brexit,fintech" }
 
             viewModel.onSearchTextChanged("text")
             delay(200)
-            assertTrue { viewModel.state.value.searchQuery == null }
+            assertTrue { viewModel.state.value.searchQuery == "brexit,fintech" }
 
             delay(301)
             assertTrue { viewModel.state.value.searchQuery == "text" }


### PR DESCRIPTION
## What does this pull request change?

Include the currently used `searchQuery` as the prompt for the Search box in iOS,

> iOS: show current search query as placeholder for search bar (no need for it to say Search I think in V1, we can just show the full search query since there’s already a :mag_right: icon)


## Screenshots

<img width="360" alt="Screenshot 2022-05-21 at 22 59 18" src="https://user-images.githubusercontent.com/5462605/169670290-7fa8586f-85b2-4bdf-95b9-aafd847e33fd.png">

<img width="373" alt="Screenshot 2022-05-21 at 23 00 55" src="https://user-images.githubusercontent.com/5462605/169670334-909b2bc9-0b1e-4a47-88fa-0ef31cd2af7f.png">


## How is this change tested?

For now there's no API call triggered, so this has been manually tested only. Worth probably some unit testing involving empty/populated query once all functionality is done


